### PR TITLE
Potential fix for code scanning alert no. 113: Code injection

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -109,7 +109,9 @@ jobs:
           credentials_json: "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_NPM_PKG }}"
       - name: Set up gcloud Cloud SDK environment
         uses: google-github-actions/setup-gcloud@v2.1.5
-      - run: echo "HEAD_REF=${{ github.head_ref }}" >> "$GITHUB_ENV"
+      - env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: echo "HEAD_REF=$HEAD_REF" >> "$GITHUB_ENV"
       - run: echo " $HEAD_REF "
       - run: |
             gcloud config set artifacts/repository everything-lib


### PR DESCRIPTION
Potential fix for [https://github.com/Zwiqler94/jz-portfolio/security/code-scanning/113](https://github.com/Zwiqler94/jz-portfolio/security/code-scanning/113)

To fix the code injection vulnerability, we should avoid directly interpolating `${{ github.head_ref }}` in the shell command. Instead, assign the value to an environment variable using the `env:` key, and then reference it using shell variable syntax (`$HEAD_REF`) in the shell command. This prevents any malicious content in `github.head_ref` from being interpreted as shell code.

**Steps to fix:**
- In the step where we set `HEAD_REF`, add an `env:` block to assign `HEAD_REF: ${{ github.head_ref }}`.
- Change the `run:` command to use `echo "HEAD_REF=$HEAD_REF" >> "$GITHUB_ENV"`.

**Required changes:**
- Edit the step at line 112 to add an `env:` block and update the `run:` command accordingly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
