### PR TITLE
chore(ci): use node 22 for version jobs

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -33,18 +33,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.APP_ACCESS_TOKEN }}
-      - name: Use Node.js 20
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+      - name: Use Node.js 22
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         uses: actions/setup-node@v4.4.0
         with:
           node-version: 22
           cache: "npm"
+      - name: log versions
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
+        run: |
+          node --version
+          npm --version
       - name: version
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: |
           git remote set-url origin https://github-actions[bot]:${{ secrets.APP_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git
           git pull --tags
@@ -54,44 +59,45 @@ jobs:
           git checkout -b "${{ github.head_ref }}"
           npm ci
           npm version patch
+          echo "version=$(node -p \"require('./package.json').version\")"
           git push
           git push --tags
       - name: set PULL_URL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: echo "PULL_URL="${{ env.REPO_URL }}/pulls"" >> "$GITHUB_ENV"
       - name: check URL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: echo "-URL-> ${{ env.PULL_URL }}"
       - name: set PULL REQ JSON
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: echo "JSON="{\"title\":\"Amazing new feature patch\",\"body\":\"Please pull these awesome changes in!\",\"head\":\"Zwiqler94:"${{ github.head_ref }}"\",\"base\":\"development\"}"" >> "$GITHUB_ENV"
       - name: check JSON
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: echo "-JSON-> ${{ env.JSON }}"
       - name: get PR Number
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: echo "PR_NUM=$(curl -L -X POST "${{ env.PULL_URL }}" -H "Accept:application/vnd.github+json" -H "Authorization:Bearer ${{ secrets.APP_ACCESS_TOKEN }}"  -H "X-GitHub-Api-Version:2022-11-28"  -d ${{ toJson(env.JSON) }} | jq -r '.number')" >> "$GITHUB_ENV"
       - name: check PR NUM
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: echo "-Curl-> ${{ env.PR_NUM }}"
       - name: set APPROVAL_URL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: echo "APPROVAL_URL="${{ env.PULL_URL }}/${{ env.PR_NUM }}/reviews"" >> "$GITHUB_ENV"
       - name: request APPROVAL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: curl --request POST "${{ env.APPROVAL_URL }}"  -H "content-type:application/json" -H 'Authorization:Bearer ${{ secrets.USER_ACCESS_TOKEN }}' -d '{"event":"APPROVE"}'
       - name: set MERGE_URL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: echo "MERGE_URL="${{ env.PULL_URL }}/${{ env.PR_NUM }}/merge"" >> "$GITHUB_ENV"
       - name: set CMT REQ JSON
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: echo "CMT_MSG="${{ toJson(needs.verify-commit.outputs.commitMsg) }}"" >> "$GITHUB_ENV"
 
       - name: check commit JSON
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: echo "-COMMIT-JSON-> ${{ env.JSON }}"
       - name: request Merge
-        if: ${{ needs.verify-commit.outputs.versionType  == 'patch' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'patch' }}
         run: curl --request PUT ${{ env.MERGE_URL }}  -H "Accept:application/vnd.github+json" -H 'Authorization:Bearer ${{ secrets.APP_ACCESS_TOKEN }}'  -H "X-GitHub-Api-Version:2022-11-28" -d '{"commit_title":"version","commit_message":" ${{ env.CMT_MSG }} [skip ci]"}'
   version-minor:
     if: ${{ github.event.pull_request.merged == true }}
@@ -99,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.APP_ACCESS_TOKEN }}
@@ -118,14 +124,19 @@ jobs:
             gcloud config set artifacts/location us-central1
             gcloud artifacts print-settings npm --scope=@zwiqler94 >> .npmrc
             npx google-artifactregistry-auth
-      - name: Use Node.js 20
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+      - name: Use Node.js 22
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         uses: actions/setup-node@v4.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
+      - name: log versions
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
+        run: |
+          node --version
+          npm --version
       - name: version
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         run: |
           git remote set-url origin https://github-actions[bot]:${{ secrets.APP_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git
           git pull --tags
@@ -135,37 +146,38 @@ jobs:
           git checkout -b "${{ github.head_ref }}"
           npm ci
           npm version minor
+          echo "version=$(node -p \"require('./package.json').version\")"
           git push
           git push --tags
       - name: set PULL_URL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         run: echo "PULL_URL="${{ env.REPO_URL }}/pulls"" >> "$GITHUB_ENV"
       - name: check URL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         run: echo "-URL-> ${{ env.PULL_URL }}"
       - name: set PULL REQ JSON
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         run: echo "JSON="{\"title\":\"Amazing new feature minor\",\"body\":\"Please pull these awesome changes in!\",\"head\":\"Zwiqler94:"${{ github.head_ref }}"\",\"base\":\"development\"}"" >> "$GITHUB_ENV"
       - name: check JSON
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         run: echo "-JSON-> ${{ env.JSON }}"
       - name: get PR Number
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         run: echo "PR_NUM=$(curl -L -X POST "${{ env.PULL_URL }}" -H "Accept:application/vnd.github+json" -H "Authorization:Bearer ${{ secrets.APP_ACCESS_TOKEN }}"  -H "X-GitHub-Api-Version:2022-11-28"  -d ${{ toJson(env.JSON) }} | jq -r '.number')" >> "$GITHUB_ENV"
       - name: check PR NUM
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         run: echo "-Curl-> ${{ env.PR_NUM }}"
       - name: set APPROVAL_URL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         run: echo "APPROVAL_URL="${{ env.PULL_URL }}/${{ env.PR_NUM }}/reviews"" >> "$GITHUB_ENV"
       - name: request APPROVAL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         run: curl --request POST "${{ env.APPROVAL_URL }}"  -H "content-type:application/json" -H 'Authorization:Bearer ${{ secrets.USER_ACCESS_TOKEN }}' -d '{"event":"APPROVE"}'
       - name: set MERGE_URL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         run: echo "MERGE_URL="${{ env.PULL_URL }}/${{ env.PR_NUM }}/merge"" >> "$GITHUB_ENV"
       - name: request Merge
-        if: ${{ needs.verify-commit.outputs.versionType  == 'minor' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
         run: curl --request PUT ${{ env.MERGE_URL }}  -H "Accept:application/vnd.github+json" -H 'Authorization:Bearer ${{ secrets.APP_ACCESS_TOKEN }}'  -H "X-GitHub-Api-Version:2022-11-28" -d '{"commit_title":"version","commit_message":"${{ needs.verify-commit.outputs.commitMsg }} [skip ci]"}'
   version-major:
     if: ${{ github.event.pull_request.merged == true }}
@@ -173,18 +185,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.APP_ACCESS_TOKEN }}
-      - name: Use Node.js 20
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+      - name: Use Node.js 22
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         uses: actions/setup-node@v4.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
+      - name: log versions
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
+        run: |
+          node --version
+          npm --version
       - name: version
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         run: |
           git remote set-url origin https://github-actions[bot]:${{ secrets.APP_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git
           git pull --tags
@@ -194,37 +211,38 @@ jobs:
           git checkout -b "${{ github.head_ref }}"
           npm ci
           npm version major
+          echo "version=$(node -p \"require('./package.json').version\")"
           git push
           git push --tags
       - name: set PULL_URL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         run: echo "PULL_URL="${{ env.REPO_URL }}/pulls"" >> "$GITHUB_ENV"
       - name: check URL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         run: echo "-URL-> ${{ env.PULL_URL }}"
       - name: set PULL REQ JSON
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         run: echo "JSON="{\"title\":\"Amazing new feature major\",\"body\":\"Please pull these awesome changes in!\",\"head\":\"Zwiqler94:"${{ github.head_ref }}"\",\"base\":\"development\"}"" >> "$GITHUB_ENV"
       - name: check JSON
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         run: echo "-JSON-> ${{ env.JSON }}"
       - name: get PR Number
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         run: echo "PR_NUM=$(curl -L -X POST "${{ env.PULL_URL }}" -H "Accept:application/vnd.github+json" -H "Authorization:Bearer ${{ secrets.APP_ACCESS_TOKEN }}"  -H "X-GitHub-Api-Version:2022-11-28"  -d ${{ toJson(env.JSON) }} | jq -r '.number')" >> "$GITHUB_ENV"
       - name: check PR NUM
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         run: echo "-Curl-> ${{ env.PR_NUM }}"
       - name: set APPROVAL_URL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         run: echo "APPROVAL_URL="${{ env.PULL_URL }}/${{ env.PR_NUM }}/reviews"" >> "$GITHUB_ENV"
       - name: request APPROVAL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         run: curl --request POST "${{ env.APPROVAL_URL }}"  -H "content-type:application/json" -H 'Authorization:Bearer ${{ secrets.USER_ACCESS_TOKEN }}' -d '{"event":"APPROVE"}'
       - name: set MERGE_URL
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         run: echo "MERGE_URL="${{ env.PULL_URL }}/${{ env.PR_NUM }}/merge"" >> "$GITHUB_ENV"
       - name: request Merge
-        if: ${{ needs.verify-commit.outputs.versionType  == 'major' }}
+        if: ${{ needs.verify-commit.outputs.versionType == 'major' }}
         run: curl --request PUT ${{ env.MERGE_URL }}  -H "Accept:application/vnd.github+json" -H 'Authorization:Bearer ${{ secrets.APP_ACCESS_TOKEN }}' -H "X-GitHub-Api-Version:2022-11-28" -d '{"commit_title":"version","commit_message":"${{ needs.verify-commit.outputs.commitMsg }} [skip ci]"}'
   skip-no-deploy:
     runs-on: ubuntu-latest
@@ -237,7 +255,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.merged == true }}
     steps:
-      - if: ${{ needs.verify-commit.outputs.versionType  == 'stop' }}
+      - if: ${{ needs.verify-commit.outputs.versionType == 'stop' }}
         run: |
             echo "::notice:: skip versioning because been there done that"
             exit 0


### PR DESCRIPTION
## Summary
- align versioning workflow on Node.js 22
- normalize spacing in version job conditions
- log runtime and package versions during version jobs

## Testing
- `npm ci` *(fails: package-lock missing chokidar, glob-parent, readdirp, picomatch, conventional-commits-parser)*
- `npm install` *(fails: Incorrect or missing password)*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e4424c308326a436f488c609e3a3