### PR TITLE
Potential fix for code scanning alert no. 139: Code injection

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -194,8 +194,10 @@ jobs:
         run: echo "-URL-> ${{ env.PULL_URL }}"
       - name: set PULL REQ JSON
         if: ${{ needs.verify-commit.outputs.versionType == 'minor' }}
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          JSON=$(jq -cn --arg head "Zwiqler94:${{ github.head_ref }}" '
+          JSON=$(jq -cn --arg head "Zwiqler94:$HEAD_REF" '
           {
             title: "chore(release): amazing new minor update",
             body: "Please pull these awesome changes in!",


### PR DESCRIPTION
Potential fix for [https://github.com/Zwiqler94/jz-portfolio/security/code-scanning/139](https://github.com/Zwiqler94/jz-portfolio/security/code-scanning/139)

To fix this, we should stop interpolating `${{ github.head_ref }}` directly into the `run:` script and instead pass it into the step as an environment variable, then use standard shell variable expansion inside the script. This matches GitHub’s recommended pattern and avoids expression syntax inside the shell script, eliminating the potential code injection avenue flagged by CodeQL.

Concretely, in the `version-minor` job’s “set PULL REQ JSON” step (lines 195–205), we will add an `env:` section that defines a variable (e.g., `HEAD_REF`) set to `${{ github.head_ref }}`. Then we will modify the `jq` command so that `--arg head` uses `"Zwiqler94:$HEAD_REF"` instead of `"Zwiqler94:${{ github.head_ref }}"`. No functional behavior changes: the resulting `head` string in the JSON remains `Zwiqler94:<head_ref>`. All other steps remain unchanged. This only requires editing `.github/workflows/version.yml` in the shown region; no additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
