### PR TITLE
ci: harden workflow checkout and scope GitHub permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge-development.yml
+++ b/.github/workflows/firebase-hosting-merge-development.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v6
+        with:
+          token: ${{ github.token }}
+          fetch-depth: 0
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v6
+        with:
+          token: ${{ github.token }}
+          fetch-depth: 0
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:

--- a/.github/workflows/firebase-hosting-pull-request-development.yml
+++ b/.github/workflows/firebase-hosting-pull-request-development.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ github.token }}
+          fetch-depth: 0
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ github.token }}
+          fetch-depth: 0
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:

--- a/.github/workflows/main-workflow-v3.yml
+++ b/.github/workflows/main-workflow-v3.yml
@@ -8,7 +8,10 @@ on:
       - opened
       - closed
       - synchronize
-permissions: write-all
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 jobs:
   versionDev:
     if: ${{ github.base_ref != 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -7,7 +7,8 @@ on:
       versionType:
         description: "the version increment type (major, minor, or patch)"
         value: ${{ jobs.verify-commit.outputs.versionType }}
-permissions: write-all
+permissions:
+  contents: read
 env:
   REPO_URL: "https://api.github.com/repos/${{ github.repository }}"
   HUSKY: 0
@@ -41,6 +42,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.APP_ACCESS_TOKEN }}
+          fetch-depth: 0
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:


### PR DESCRIPTION
## Summary
- Add explicit `github.token` usage and full fetch history to Firebase Hosting checkout steps so workflow runs have the needed repository context.
- Narrow GitHub Actions permissions in the main and version workflows from `write-all` to the specific scopes they use.
- Keep versioning and hosting workflows aligned with least-privilege access.

## Testing
- Not run (not requested)